### PR TITLE
create user specified job parser

### DIFF
--- a/src/@types/app.ts
+++ b/src/@types/app.ts
@@ -1,7 +1,9 @@
+import * as Redis from 'ioredis'
+
 import { Job, JobOptions } from 'bull'
 import { Job as JobMq, JobsOptions } from 'bullmq'
+
 import React from 'react'
-import * as Redis from 'ioredis'
 import { Status } from '../ui/components/constants'
 
 export type JobCleanStatus =
@@ -11,12 +13,17 @@ export type JobCleanStatus =
   | 'delayed'
   | 'failed'
 
+export type AdapterOptions = {
+  jobParser(job: Job | JobMq): AppJob
+}
+
 export type JobStatus = Status
 
 export type JobCounts = Record<JobStatus, number>
 
 export interface QueueAdapter {
   readonly client: Promise<Redis.Redis>
+  readonly options?: AdapterOptions
   getName(): string
 
   getJob(id: string): Promise<Job | JobMq | undefined | null>
@@ -64,6 +71,8 @@ export interface AppJob {
   delay: number | undefined
   returnValue: string | Record<string | number, any> | null
 }
+
+export type DataFormatter = (data: JobMq['data']) => JobMq['data']
 
 export interface AppQueue {
   name: string

--- a/src/queueAdapters/bull.ts
+++ b/src/queueAdapters/bull.ts
@@ -1,17 +1,18 @@
-import { Job, Queue } from 'bull'
 import {
+  AdapterOptions,
   JobCleanStatus,
   JobCounts,
   JobStatus,
   QueueAdapter,
 } from '../@types/app'
+import { Job, Queue } from 'bull'
 
 export class BullAdapter implements QueueAdapter {
   public get client() {
     return Promise.resolve(this.queue.client)
   }
 
-  constructor(public queue: Queue) {}
+  constructor(public queue: Queue, public options: AdapterOptions) {}
 
   public getName(): string {
     return this.queue.name


### PR DESCRIPTION
User can now specify AdapterOptions passed to the BullAdapter on
creation. In this user can specify the jobParser, which provides an
alternative way to parse job data to be displayed in the Jobs List UI